### PR TITLE
Gui tests suri integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libs/mupdf"]
 	path = libs/mupdf
 	url = https://github.com/ArtifexSoftware/mupdf.git
+[submodule "tests/gui_tests/suri"]
+	path = tests/gui_tests/suri
+	url = https://github.com/CyberAlpaca/suri.git

--- a/tests/gui_tests/CMakeLists.txt
+++ b/tests/gui_tests/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Gui Quick Test)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Qml Quick Test Concurrent)
 find_package(Qt6 REQUIRED COMPONENTS QuickControls2)
 
+add_subdirectory(suri)
+
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -56,6 +58,7 @@ target_link_libraries(GuiTests
         Qt${QT_VERSION_MAJOR}::Test
         Qt${QT_VERSION_MAJOR}::QuickControls2
         ${MUPDF_OUTPUT}
+        suri
 )
 
 target_include_directories(GuiTests

--- a/tests/gui_tests/tst_guitests.cpp
+++ b/tests/gui_tests/tst_guitests.cpp
@@ -8,7 +8,7 @@
 #include <QQmlExpression>
 #include <QQmlContext>
 #include <QQmlProperty>
-
+#include <suri/automator.h>
 
 class GuiTests : public QObject
 {
@@ -18,7 +18,6 @@ private:
     QQuickWindow *window;
     QPointer<QApplication> app;
     QPointer<QQmlApplicationEngine> engine;
-    void click(QQuickItem*);
     QQuickItem* findItemById(const QString &aName);
 
 public:
@@ -30,14 +29,6 @@ private slots:
     void cleanupTestCase();
     void test_case1();
 };
-
-void GuiTests::click(QQuickItem* obj){
-    auto lPointF = obj->mapToScene( QPoint( 0, 0 ) );
-    auto lPoint = lPointF.toPoint();
-    lPoint.rx() += obj->width() / 2;
-    lPoint.ry() += obj->height() / 2;
-    QTest::mouseClick( window, Qt::LeftButton, Qt::NoModifier, lPoint );
-}
 
 GuiTests::GuiTests(QPointer<QApplication> app, QPointer<QQmlApplicationEngine> engine)
 {
@@ -84,13 +75,15 @@ void GuiTests::cleanupTestCase()
 
 void GuiTests::test_case1()
 {
+
+    Automator automator(engine);
+
     QObject *loginButtonPure = window->findChild<QObject*>("loginButton");
     QQuickItem *buttonItem1Directly = window->findChild<QQuickItem*>("loginButton");
     QQuickItem *buttonItemCast = qobject_cast<QQuickItem*>(loginButtonPure);
 
     QQuickItem *link = window->findChild<QQuickItem*>("forgotPasswordLabel");
-
-    click(link);
+    automator.click(link);
 
     QTest::qSleep(20000);
 }


### PR DESCRIPTION
-  Use the external library suri as a submodule for GUI Tests. 
- Update the example Test Case to use the click method from this library.
