### PR TITLE
Fix issue with controllers lifecycle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,15 +29,15 @@ add_subdirectory(presentation/)
 set(app_icon_resource_windows "${CMAKE_CURRENT_SOURCE_DIR}/resources.rc")
 qt_add_executable(librum
     main.cpp
-    application_init.h
-    application_init.cpp
     dependency_injection.hpp
     message_handler.hpp
     ${PROJECT_SOURCE_DIR}/fonts.qrc
     ${app_icon_resource_windows}
     ${QM_FILES}
-
-
+    application_init.h
+    application_init.cpp
+    global_controllers.h
+    global_controllers.cpp
 )
 
 # Set WIN32 for windows to avoid console getting opened on start on windows

--- a/src/application_init.cpp
+++ b/src/application_init.cpp
@@ -42,6 +42,7 @@
 #include "tools_controller.hpp"
 #include "user_controller.hpp"
 #include "word_definition_dto.hpp"
+#include "global_controllers.h"
 
 
 using namespace adapters::controllers;
@@ -94,80 +95,80 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
             // Authentication Stack
     auto* authenticationService =
         config::diConfig().create<application::IAuthenticationService*>();
-    auto authenticationController =
+    GlobalControllers::authenticationController =
         std::make_unique<AuthenticationController>(authenticationService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "AuthController",
-                                 authenticationController.get());
+                                 GlobalControllers::authenticationController.get());
 
             // App Info Stack
     auto* appInfoService =
         config::diConfig().create<application::IAppInfoService*>();
-    auto appInfoController =
+    GlobalControllers::appInfoController =
         std::make_unique<AppInfoController>(appInfoService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "AppInfoController",
-                                 appInfoController.get());
+                                 GlobalControllers::appInfoController.get());
 
             // Ai explanation
     auto* aiExplanationService =
         config::diConfig().create<application::IAiExplanationService*>();
-    auto aiExplanationController =
+    GlobalControllers::aiExplanationController =
         std::make_unique<AiExplanationController>(aiExplanationService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "AiExplanationController",
-                                 aiExplanationController.get());
+                                 GlobalControllers::aiExplanationController.get());
 
             // User Stack
     auto* userService = config::diConfig().create<application::IUserService*>();
-    auto userController = std::make_unique<UserController>(userService);
+    GlobalControllers::userController = std::make_unique<UserController>(userService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "UserController",
-                                 userController.get());
+                                 GlobalControllers::userController.get());
 
             // Dictionary Stack
     auto* dictionaryService = config::diConfig().create<application::IDictionaryService*>();
-    auto dictionaryController = std::make_unique<DictionaryController>(dictionaryService);
+    GlobalControllers::dictionaryController = std::make_unique<DictionaryController>(dictionaryService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "DictionaryController",
-                                 dictionaryController.get());
+                                 GlobalControllers::dictionaryController.get());
 
             // Folder Stack
     auto* folderService = config::diConfig().create<application::IFolderService*>();
-    auto folderController = std::make_unique<FolderController>(folderService);
+    GlobalControllers::folderController = std::make_unique<FolderController>(folderService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "FolderController",
-                                 folderController.get());
+                                 GlobalControllers::folderController.get());
 
             // Library Stack
     auto* libraryService = config::diConfig().create<application::ILibraryService*>();
-    auto libraryController = std::make_unique<LibraryController>(libraryService);
+    GlobalControllers::libraryController = std::make_unique<LibraryController>(libraryService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "LibraryController",
-                                 libraryController.get());
+                                 GlobalControllers::libraryController.get());
 
             // Book Stack
     auto bookService = std::make_unique<application::services::BookService>();
-    auto bookController = std::make_unique<BookController>(bookService.get(), libraryService);
+    GlobalControllers::bookController = std::make_unique<BookController>(bookService.get(), libraryService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "BookController",
-                                 bookController.get());
+                                 GlobalControllers::bookController.get());
 
             // External Book Stack
     auto externalBookService = std::make_unique<application::services::BookService>();
-    auto externalBookController = std::make_unique<ExternalBookController>(externalBookService.get());
+    GlobalControllers::externalBookController = std::make_unique<ExternalBookController>(externalBookService.get());
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "ExternalBookController",
-                                 externalBookController.get());
+                                 GlobalControllers::externalBookController.get());
 
             // Free books stack
     auto* freeBooksService = config::diConfig().create<application::IFreeBooksService*>();
-    auto freeBooksController = std::make_unique<FreeBooksController>(freeBooksService);
+    GlobalControllers::freeBooksController = std::make_unique<FreeBooksController>(freeBooksService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "FreeBooksController",
-                                 freeBooksController.get());
+                                 GlobalControllers::freeBooksController.get());
 
             // Settings Stack
     auto* settingsService = config::diConfig().create<application::ISettingsService*>();
-    auto settingsController = std::make_unique<SettingsController>(settingsService);
+    GlobalControllers::settingsController = std::make_unique<SettingsController>(settingsService);
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "SettingsController",
-                                 settingsController.get());
+                                 GlobalControllers::settingsController.get());
 
             // Tools Stack
     auto toolsService = std::make_unique<application::services::ToolsService>(libraryService);
-    auto toolsController = std::make_unique<ToolsController>(toolsService.get());
+    GlobalControllers::toolsController = std::make_unique<ToolsController>(toolsService.get());
     qmlRegisterSingletonInstance("Librum.controllers", 1, 0, "ToolsController",
-                                 toolsController.get());
+                                 GlobalControllers::toolsController.get());
 
             // Enums
     qmlRegisterUncreatableMetaObject(application::book_operation_status::staticMetaObject, "Librum.controllers",
@@ -228,9 +229,9 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
     QObject::connect(userService, &application::IUserService::bookStorageDataUpdated,
                      libraryService, &application::ILibraryService::updateUsedBookStorage);
 
-    QObject::connect(libraryController.get(),
+    QObject::connect(GlobalControllers::libraryController.get(),
                      &adapters::ILibraryController::downloadedProjectGutenbergIdsReady,
-                     freeBooksController.get(),
+                     GlobalControllers::freeBooksController.get(),
                      &adapters::IFreeBooksController::proccessDownloadedProjectGutenbergIds);
 
             // Startup
@@ -239,7 +240,7 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
     QQuickStyle::setStyle("Basic");
     engine->addImportPath("qrc:/modules");
     engine->addImportPath(QCoreApplication::applicationDirPath() + "/src/presentation/qt_tree_view/qml/");
-    appInfoController->setQmlApplicationEngine(engine);
+    GlobalControllers::appInfoController->setQmlApplicationEngine(engine);
 
 
             // Setup translations
@@ -252,7 +253,7 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
         for(const QString& locale : uiLanguages)
         {
             const QString name = QLocale(locale).name();
-            if(appInfoController->switchToLanguage(name))
+            if(GlobalControllers::appInfoController->switchToLanguage(name))
             {
                 break;
             }
@@ -260,7 +261,7 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
     }
     else
     {
-        appInfoController->switchToLanguage(storedLanguage);
+        GlobalControllers::appInfoController->switchToLanguage(storedLanguage);
     }
 
     if(app->arguments().size() == 2)
@@ -273,7 +274,7 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
             QCoreApplication::exit(-1);
         }
 
-        auto setupSuccess = externalBookController->setUp(filePath);
+        auto setupSuccess = GlobalControllers::externalBookController->setUp(filePath);
         if(!setupSuccess)
         {
             std::cerr << "The file type of: " << filePath.toStdString() << " is not supported.\n";

--- a/src/application_init.h
+++ b/src/application_init.h
@@ -1,6 +1,4 @@
-#ifndef APPLICATION_INIT_H
-#define APPLICATION_INIT_H
-
+#pragma once
 #include <QApplication>
 #include <QQuickStyle>
 #include <QGuiApplication>
@@ -10,5 +8,3 @@ QPair<QPointer<QApplication>, QPointer<QQmlApplicationEngine>> initializeApplica
 void setupGlobalSettings();
 void loadFont(const QString& path);
 void setupFonts();
-
-#endif // APPLICATION_INIT_H

--- a/src/global_controllers.cpp
+++ b/src/global_controllers.cpp
@@ -1,0 +1,15 @@
+#include "global_controllers.h"
+
+std::unique_ptr<AuthenticationController> GlobalControllers::authenticationController = nullptr;
+std::unique_ptr<AppInfoController> GlobalControllers::appInfoController = nullptr;
+std::unique_ptr<AiExplanationController> GlobalControllers::aiExplanationController = nullptr;
+std::unique_ptr<UserController> GlobalControllers::userController = nullptr;
+std::unique_ptr<DictionaryController> GlobalControllers::dictionaryController = nullptr;
+std::unique_ptr<FolderController> GlobalControllers::folderController = nullptr;
+std::unique_ptr<LibraryController> GlobalControllers::libraryController = nullptr;
+std::unique_ptr<BookController> GlobalControllers::bookController = nullptr;
+std::unique_ptr<ExternalBookController> GlobalControllers::externalBookController = nullptr;
+std::unique_ptr<FreeBooksController> GlobalControllers::freeBooksController = nullptr;
+std::unique_ptr<SettingsController> GlobalControllers::settingsController = nullptr;
+std::unique_ptr<ToolsController> GlobalControllers::toolsController = nullptr;
+

--- a/src/global_controllers.h
+++ b/src/global_controllers.h
@@ -1,0 +1,37 @@
+#ifndef GLOBALS_HPP
+#define GLOBALS_HPP
+
+#include <memory>
+#include "authentication_controller.hpp"
+#include "app_info_controller.hpp"
+#include "ai_explanation_controller.hpp"
+#include "user_controller.hpp"
+#include "dictionary_controller.hpp"
+#include "folder_controller.hpp"
+#include "library_controller.hpp"
+#include "book_controller.hpp"
+#include "external_book_controller.hpp"
+#include "free_books_controller.hpp"
+#include "settings_controller.hpp"
+#include "tools_controller.hpp"
+
+
+using namespace adapters::controllers;
+
+class GlobalControllers {
+public:
+    static std::unique_ptr<AuthenticationController> authenticationController;
+    static std::unique_ptr<AppInfoController> appInfoController;
+    static std::unique_ptr<AiExplanationController> aiExplanationController;
+    static std::unique_ptr<UserController> userController;
+    static std::unique_ptr<DictionaryController> dictionaryController;
+    static std::unique_ptr<FolderController> folderController;
+    static std::unique_ptr<LibraryController> libraryController;
+    static std::unique_ptr<BookController> bookController;
+    static std::unique_ptr<ExternalBookController> externalBookController;
+    static std::unique_ptr<FreeBooksController> freeBooksController;
+    static std::unique_ptr<SettingsController> settingsController;
+    static std::unique_ptr<ToolsController> toolsController;
+};
+
+#endif // GLOBALS_HPP

--- a/src/global_controllers.h
+++ b/src/global_controllers.h
@@ -1,6 +1,4 @@
-#ifndef GLOBALS_HPP
-#define GLOBALS_HPP
-
+#pragma once
 #include <memory>
 #include "authentication_controller.hpp"
 #include "app_info_controller.hpp"
@@ -33,5 +31,3 @@ public:
     static std::unique_ptr<SettingsController> settingsController;
     static std::unique_ptr<ToolsController> toolsController;
 };
-
-#endif // GLOBALS_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,5 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    // return app->exec();
-
-    return QGuiApplication::exec();
+    return app->exec();
 }

--- a/tests/gui_tests/CMakeLists.txt
+++ b/tests/gui_tests/CMakeLists.txt
@@ -21,10 +21,12 @@ set(RESOURCE_FILE_PATH ${CMAKE_SOURCE_DIR}/src/presentation/qmlSources.qrc)
 message("===== RESOURCE_FILE_PATH: " ${CMAKE_SOURCE_DIR})
 qt6_add_resources(RESOURCES ${RESOURCE_FILE_PATH})
 set(INITAPP_PATH ${CMAKE_SOURCE_DIR}/src/application_init.cpp)
+set(GLOB_CONTROLLERS_PATH ${CMAKE_SOURCE_DIR}/src/global_controllers.cpp)
 
 add_executable(GuiTests
     tst_guitests.cpp
     ${INITAPP_PATH}
+    ${GLOB_CONTROLLERS_PATH}
     ${RESOURCES}
 )
 add_test(NAME GuiTests COMMAND GuiTests)


### PR DESCRIPTION
Once the initializeApplication function was executed, the controller objects were destroyed, thus they were unreachable from QML code. I introduced a GlobalCotrollers class to keep these objects live during whole runtime of the application.
